### PR TITLE
Upgrade Ruby to 3.1.2 to support Heroku-22 stack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "http://rubygems.org"
 ruby '3.1.2'
 
 gem "sinatra"
+
+gem "puma", "~> 6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "http://rubygems.org"
 
-ruby '2.5.1'
+ruby '3.1.0'
 
 gem "sinatra"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "http://rubygems.org"
 
-ruby '3.1.0'
+ruby '3.1.2'
 
 gem "sinatra"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ DEPENDENCIES
   sinatra
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 3.1.2p20
 
 BUNDLED WITH
    1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,27 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    mustermann (1.0.3)
-    rack (2.0.6)
-    rack-protection (2.0.4)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.5.8)
+    puma (6.0.0)
+      nio4r (~> 2.0)
+    rack (2.2.4)
+    rack-protection (3.0.4)
       rack
-    sinatra (2.0.4)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.4)
+    ruby2_keywords (0.0.5)
+    sinatra (3.0.4)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.4)
       tilt (~> 2.0)
-    tilt (2.0.9)
+    tilt (2.0.11)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  puma (~> 6.0)
   sinatra
 
 RUBY VERSION


### PR DESCRIPTION
The server at [hangman-api.herokuapp.com](http://hangman-api.herokuapp.com/) sopped working.
Couldn't  really figure out  why but when I tried to  deploy it to Heroku myself I figured that Heroku-18
stack is deprecated,  and the new stack Heroku-22 only supports Ruby 3.1.0 or higher.